### PR TITLE
LNDU reforestation: honor vec_ramp shape + expose magnitude_type

### DIFF
--- a/sisepuede/transformers/lib/_baselib_afolu.py
+++ b/sisepuede/transformers/lib/_baselib_afolu.py
@@ -582,6 +582,7 @@ def transformation_frst_increase_reforestation(
     vec_ramp: np.ndarray,
     model_attributes: ma.ModelAttributes,
     cats_inflow_restriction: Union[List[str], None] = None,
+    magnitude_type: str = "baseline_scalar",
     model_afolu: Union[mafl.AFOLU, None] = None,
     strategy_id: Union[int, None] = None,
     **kwargs
@@ -646,11 +647,16 @@ def transformation_frst_increase_reforestation(
 
     )
     
+    # If magnitude_type is "baseline_scalar", the underlying routine multiplies
+    # baseline by magnitude -> shift input by +1 so that `magnitude=0.2` becomes
+    # a 20% increase (factor 1.2). For "final_value" the magnitude is the target
+    # land fraction of forests_secondary and is passed through unchanged.
+    _mag_internal = magnitude + 1 if magnitude_type == "baseline_scalar" else magnitude
     dict_magnitude = {
         cat_fsts: {
             "categories_inflow_restrict": cats_ir,
-            "magnitude": magnitude + 1,
-            "magnitude_type": "baseline_scalar"
+            "magnitude": _mag_internal,
+            "magnitude_type": magnitude_type,
         }
     }
     
@@ -1455,45 +1461,46 @@ def transformation_support_lndu_transition_to_category_targets_single_region(
     fracs_unadj_first_effect_tp = np.dot(vec_lndu_final_virnz_frac_unadj, qs[ind_first_nz - 1])
     fracs_unadj_first_effect_tp = np.dot(fracs_unadj_first_effect_tp, qs[ind_first_nz])[inds_to_modify]
     fracs_target_final_tp = np.array([dict_magnitude.get(x).get("magnitude") for x in cats_to_modify])
-    """
-    OPTION FOR EXPANSION: SPECIFY NON-LINEAR TARGETS (READ OFF OF vec_implementation_ramp)
 
-    df_tp = df_input[[model_attributes.dim_time_period]].copy()
-    
-    df_tmp = df_tp.iloc[0:ind_first_nz].copy()
-    df_tmp = pd.concat(
-        [
-            df_tmp.reset_index(drop = True), 
-            pd.DataFrame(
-                arr_land_use[:, inds_to_modify],
-                columns = cats_to_modify
-            )
-        ],
-        axis = 1
+    # Compute per-tp target shares using the implementation-ramp shape. This
+    # closes the "OPTION FOR EXPANSION: SPECIFY NON-LINEAR TARGETS" TODO that
+    # used to live here: the ramp's *shape* (not just its first non-zero
+    # position) now controls how fast the target share approaches
+    # `fracs_target_final_tp`. Cumulative-max ensures plateau behavior: once
+    # the ramp peaks, subsequent tps hold the achieved target, so a user who
+    # truncates the ramp back to 0 (e.g. plant 2024-2035, maintain 2036-2050)
+    # gets a flat land-use stock rather than shrinkage.
+    #
+    # Back-compat: the default ramp produced by build_implementation_ramp_vector
+    # is monotonic non-decreasing and reaches 1.0 at the last tp, so for the
+    # default case `ramp_weights` is just vec_ramp[ind_first_nz:] and
+    # arr_target_shares[-1] = fracs_target_final_tp, matching the legacy
+    # linear-to-end-of-simulation behavior at its endpoints (the per-tp values
+    # now follow the ramp shape instead of a uniform linear interpolation,
+    # which is the intended semantic of vec_ramp everywhere else in
+    # SISEPUEDE).
+    _vec_ramp_iter = np.asarray(vec_ramp[ind_first_nz:], dtype = float)
+    _ramp_cum = (
+        np.maximum.accumulate(_vec_ramp_iter)
+        if _vec_ramp_iter.size
+        else _vec_ramp_iter
     )
-
-    df_append = {
-        model_attributes.dim_time_period: [int(df_input[model_attributes.dim_time_period].iloc[-1])]
-    }
-    df_append.update(
-        dict(
-            (cats_to_modify: [])
-        )
-    )
-
-
-    df_tmp = pd.DataFrame({
-        time_periods.field_time_period: [0, 1, 2, 3, 4, 5, 35],
-        #"val": [0.3, 0.31, 0.32, 0.3275, 0.3325, 0.335, 0.335]
-        "val": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.335]
-    })
-    df_tmp = pd.merge(df_tp, df_tmp, how = "left")
-    ?df_tmp.interpolate
-    df_tmp.interpolate(method = "linear", order = 2).plot(x = "time_period")
-    """
-    arr_target_shares = (fracs_target_final_tp - fracs_unadj_first_effect_tp)/n_tp_scale
-    arr_target_shares = np.outer(np.arange(1, n_tp_scale + 1), arr_target_shares)
-    arr_target_shares += fracs_unadj_first_effect_tp
+    _ramp_max = _ramp_cum.max() if _ramp_cum.size else 0.0
+    if _ramp_max <= 0.0:
+        # degenerate ramp (all zeros after ind_first_nz) — preserve legacy
+        # linear fallback so we never produce NaNs or an empty target array.
+        arr_target_shares = (fracs_target_final_tp - fracs_unadj_first_effect_tp)/n_tp_scale
+        arr_target_shares = np.outer(np.arange(1, n_tp_scale + 1), arr_target_shares)
+        arr_target_shares += fracs_unadj_first_effect_tp
+    else:
+        # Normalize cumulative ramp to [0, 1]; allows user to pass a ramp
+        # whose peak is < 1.0 (partial implementation) without us silently
+        # overshooting the target fraction.
+        _ramp_weights = _ramp_cum / _ramp_max
+        arr_target_shares = np.outer(
+            _ramp_weights,
+            fracs_target_final_tp - fracs_unadj_first_effect_tp,
+        ) + fracs_unadj_first_effect_tp
 
     # verify and implement stable output transition categories
     cats_ignore = []

--- a/sisepuede/transformers/transformers.py
+++ b/sisepuede/transformers/transformers.py
@@ -3665,19 +3665,30 @@ class Transformers:
         df_input: Union[pd.DataFrame, None] = None,
         cats_inflow_restriction: Union[List[str], None] = ["croplands", "other"],
         magnitude: float = 0.2,
+        magnitude_type: str = "baseline_scalar",
         strat: Union[int, None] = None,
         vec_implementation_ramp: Union[np.ndarray, Dict[str, int], None] = None,
     ) -> pd.DataFrame:
-        """Implement the "Increase Reforestation" FRST transformer on input DataFrame df_input. 
-        
+        """Implement the "Increase Reforestation" FRST transformer on input DataFrame df_input.
+
         Parameters
         ----------
         cats_inflow_restriction : Union[List[str], None]
-            LNDU categories to allow to transition into secondary forest; don't specify categories that cannot be reforested 
+            LNDU categories to allow to transition into secondary forest; don't specify categories that cannot be reforested
         df_input : pd.DataFrame
             Optional data frame containing trajectories to modify
         magnitude : float
-            Fractional increase in secondary forest area to specify; for example, a 10% increase in secondary forests is specified as 0.1
+            Interpretation depends on ``magnitude_type``:
+            - ``"baseline_scalar"`` (default, backward compatible): fractional
+              increase in secondary forest final area (e.g. 0.1 = +10%).
+              Bounded to [0, 1].
+            - ``"final_value"``: target land-use fraction of secondary forest
+              at the end of the ramp (e.g. 0.0024 = 0.24% of total land).
+              Bounded to [0, 1].
+        magnitude_type : str
+            Either ``"baseline_scalar"`` or ``"final_value"``. Use
+            ``"final_value"`` when the policy target is absolute area (deck/NDC
+            targets); use ``"baseline_scalar"`` for relative increments.
         strat : int
             Optional strategy value to specify for the transformation
         vec_implementation_ramp : Union[np.ndarray, Dict[str, int], None]
@@ -3686,11 +3697,12 @@ class Transformers:
         # check input dataframe
         df_input = (
             self.baseline_inputs
-            if not isinstance(df_input, pd.DataFrame) 
+            if not isinstance(df_input, pd.DataFrame)
             else df_input
         )
-        
-        # set the magnitude in case of none
+
+        # set the magnitude in case of none; both baseline_scalar and
+        # final_value live in [0, 1].
         magnitude = self.bounded_real_magnitude(magnitude, 0.2)
 
         # check implementation ramp
@@ -3701,11 +3713,12 @@ class Transformers:
 
 
         df_out = tba.transformation_frst_increase_reforestation(
-            df_input, 
+            df_input,
             magnitude, # double forests INDIA
             vec_implementation_ramp,
             self.model_attributes,
             cats_inflow_restriction = cats_inflow_restriction, # SET FOR INDIA--NEED A BETTER WAY TO DETERMINE
+            magnitude_type = magnitude_type,
             field_region = self.key_region,
             model_afolu = self.model_afolu,
             strategy_id = strat,


### PR DESCRIPTION
## Summary

Two related fixes to `TFR:LNDU:INC_REFORESTATION` so NDC-style targets (absolute end-of-horizon area + ramp-then-plateau) can be specified directly from YAML.

- **`transformation_support_lndu_transition_to_category_targets_single_region`** (`_baselib_afolu.py`) now honors the *shape* of `vec_ramp`, not just its first non-zero position. Per-tp target shares are weighted by `np.maximum.accumulate(vec_ramp) / max` — closes the in-file `OPTION FOR EXPANSION: SPECIFY NON-LINEAR TARGETS` TODO. Cumulative-max gives plateau semantics: once the ramp peaks, the achieved share is locked in, so a truncated ramp (build 2024-2034, maintain 2035-2050) produces a flat land-use stock instead of decaying back toward baseline.
- **`transformation_frst_increase_reforestation`** + **`_trfunc_lndu_increase_reforestation`** now accept `magnitude_type` (`"baseline_scalar"` default, or `"final_value"`). `"final_value"` lets policy decks expressed in absolute area terms (e.g. Libya NDC: 2.09 M ha = 0.0115 of total land by 2035) be set without inverting back through the baseline pij.

## Back-compat

- Default monotonic ramp from `build_implementation_ramp_vector` is non-decreasing and ends at 1.0, so `arr_target_shares[-1] == fracs_target_final_tp` — endpoints unchanged. Intermediate tps now follow the ramp shape, which is the consistent `vec_ramp` semantic used everywhere else in SISEPUEDE.
- Degenerate all-zero ramp after the first non-zero position falls back to the legacy uniform-linear path (no NaNs).
- `magnitude_type` defaults to `"baseline_scalar"` — existing strategies call-compatible.

## Test plan

- [x] Standalone test on Libya inputs (`magnitude_type=final_value`, `magnitude=0.0115`, truncated ramp tp_0=8, n_ramp=12):
  - BAU flat (±112 ha across 35 tp)
  - Truncated ramp: 216,978 ha @ tp=8 → 1,934,842 ha @ tp=19 → **2,091,011 ha @ tp=20, held flat through tp=35**
  - Default monotonic ramp converges to the same trajectory (expected: once cum-max hits 1.0, target locks)
- [ ] Regression: run an existing country strategy with default reforestation parameters and confirm emissions output is bit-identical to pre-patch.