### PR TITLE
fix(logging): avoid duplicate log output on re-runs in the same kernel

### DIFF
--- a/sisepuede/manager/sisepuede.py
+++ b/sisepuede/manager/sisepuede.py
@@ -850,22 +850,30 @@ class SISEPUEDE:
                 else self.file_struct.fp_log_default
             )
 
-            # setup logger
-            logging.basicConfig(
-                filename = fn_out,
-                filemode = "w",
-                format = format_str,
-                level = logging.DEBUG
-            )
-
             logger = logging.getLogger(namespace)
 
-            # create console handler and set level to debug
+            # Remove any pre-existing handlers so re-running in the same kernel
+            # (e.g. a Jupyter notebook) does not duplicate log output.
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+                handler.close()
+
+            logger.setLevel(logging.DEBUG)
+            logger.propagate = False
+
+            formatter = logging.Formatter(format_str)
+
+            # file handler (replaces logging.basicConfig, which is a no-op on
+            # subsequent calls and would otherwise pin file output to the path
+            # used on the first run).
+            fh = logging.FileHandler(fn_out, mode = "w")
+            fh.setLevel(logging.DEBUG)
+            fh.setFormatter(formatter)
+            logger.addHandler(fh)
+
+            # console handler
             ch = logging.StreamHandler()
             ch.setLevel(logging.DEBUG)
-
-            # create formatter, add to console handler, and add the handler to logger
-            formatter = logging.Formatter(format_str)
             ch.setFormatter(formatter)
             logger.addHandler(ch)
 

--- a/sisepuede/utilities/_toolbox.py
+++ b/sisepuede/utilities/_toolbox.py
@@ -4008,29 +4008,29 @@ def setup_logger(
         else format_str
     )
 
-    # configure
-    if isinstance(fn_out, str):
-        logging.basicConfig(
-            filename = fn_out,
-            filemode = "w",
-            format = format_str,
-            level = logging.DEBUG
-        )
-        
-    else:
-        logging.basicConfig(
-            format = format_str,
-            level = logging.DEBUG
-        )
-
     logger = logging.getLogger(namespace)
 
-    # create console handler and set level to debug
+    # Remove any pre-existing handlers so re-running in the same kernel
+    # (e.g. a Jupyter notebook) does not duplicate log output.
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    formatter = logging.Formatter(format_str)
+
+    # optional file handler
+    if isinstance(fn_out, str):
+        fh = logging.FileHandler(fn_out, mode = "w")
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    # console handler
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
-
-    # create formatter, add to channel, and the channel to the logger
-    formatter = logging.Formatter(format_str)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
 


### PR DESCRIPTION
## Summary
- Re-instantiating `SISEPUEDE` in the same Python kernel (e.g. a Jupyter notebook) appended a new `StreamHandler` to the cached named logger on every call, so each subsequent run multiplied the console output (2×, 3×, …).
- Root cause: `logging.getLogger(namespace)` returns the same singleton, and `_initialize_logger` / `setup_logger` called `addHandler` unconditionally.
- Secondary issue: `logging.basicConfig` is a no-op after the first invocation, so `fp_log` was effectively pinned to the path used on the first run.

## Changes
- `sisepuede/manager/sisepuede.py` — `_initialize_logger`: remove any pre-existing handlers (and close them) before adding new ones; replace `basicConfig` with an explicit `FileHandler(mode="w")`; set `logger.propagate = False`.
- `sisepuede/utilities/_toolbox.py` — `setup_logger`: same treatment.

## Test plan
- [x] Isolated repro: calling the setup function 3× in the same process keeps `len(logger.handlers) == 1` and each `info()` prints exactly once.
- [ ] Reviewer: instantiate `SISEPUEDE` twice in a Jupyter notebook without restarting the kernel and confirm log lines are not duplicated, and that the second run's file logs land in the new `fp_log`.

https://claude.ai/code/session_01V9QvszaFCo53aH9E2jozZm

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QvszaFCo53aH9E2jozZm)_